### PR TITLE
Refactored resources usage in AssetManager

### DIFF
--- a/annileen/editor/editorgui.ixx
+++ b/annileen/editor/editorgui.ixx
@@ -1035,7 +1035,7 @@ namespace annileen
 				for (auto& [k, v] : material->getSerializedUniforms())
 				{
 					ImGui::Spacing();
-					ImGui::Checkbox(k.c_str(), &v.m_Active);
+					ImGui::Checkbox(k.c_str(), &v.active);
 				}
 			}
 		}

--- a/annileen/engine/asset.ixx
+++ b/annileen/engine/asset.ixx
@@ -2,6 +2,7 @@ module;
 
 #include <vector>
 #include <string>
+#include <memory>
 
 export module asset;
 
@@ -25,11 +26,11 @@ export namespace annileen
 
 	struct AssetTableEntry
 	{
-		std::string m_Filepath;
-		AssetType m_Type;
+		std::string m_Filepath{""};
+		AssetType m_Type{ AssetType::Undefined };
 
-		bool m_Loaded;
-		AssetObject* m_Asset;
+		bool m_Loaded{ false };
+		std::shared_ptr<AssetObject> m_Asset{ nullptr };
 	};
 
 	enum class ShaderUniformType
@@ -73,7 +74,7 @@ export namespace annileen
 		Normals m_Normals;
 	};
 
-	struct ShaderDcescritor
+	struct ShaderDescriptor
 	{
 		std::vector<ShaderAvailableUniform> m_AvailableUniforms;
 	};

--- a/annileen/engine/assetmanager.ixx
+++ b/annileen/engine/assetmanager.ixx
@@ -292,12 +292,12 @@ namespace annileen
 			shader->setHandle(programHandle);
 			shader->setAvailableShaders(descriptor.m_AvailableUniforms);
 
-			vert->m_Asset = dynamic_pointer_cast<AssetObject>(shader);
+			vert->m_Asset = static_pointer_cast<AssetObject>(shader);
 			vert->m_Loaded = true;
 		}
 		else
 		{
-			auto shader = dynamic_pointer_cast<Shader>(vert->m_Asset);
+			auto shader = static_pointer_cast<Shader>(vert->m_Asset);
 			shader->destroy();
 			shader->setHandle(programHandle);
 			shader->setAvailableShaders(descriptor.m_AvailableUniforms);
@@ -337,7 +337,7 @@ namespace annileen
 			loadAssetShader(entry);
 		}
 		
-		return dynamic_pointer_cast<Shader>(entry->m_Asset);
+		return static_pointer_cast<Shader>(entry->m_Asset);
 	}
 
 	std::shared_ptr<Texture> AssetManager::getTexture(const std::string& tex)
@@ -345,7 +345,7 @@ namespace annileen
 		auto entry = getAssetEntry(tex);
 		if (entry->m_Loaded)
 		{
-			return dynamic_pointer_cast<Texture>(entry->m_Asset);
+			return static_pointer_cast<Texture>(entry->m_Asset);
 		}
 
 		auto descriptor = loadTextureDescriptor(entry);
@@ -356,7 +356,7 @@ namespace annileen
 		std::tie(handle, info, imageContainer) = loadTextureData(entry->m_Filepath, descriptor);
 
 		auto texture = std::make_shared<Texture>(handle, info, imageContainer->m_orientation);
-		entry->m_Asset = dynamic_pointer_cast<AssetObject>(texture);
+		entry->m_Asset = static_pointer_cast<AssetObject>(texture);
 		entry->m_Loaded = true;
 		return texture;
 	}
@@ -366,7 +366,7 @@ namespace annileen
 		auto entry = getAssetEntry(name);
 		if (entry->m_Loaded)
 		{
-			return dynamic_pointer_cast<Cubemap>(entry->m_Asset);
+			return static_pointer_cast<Cubemap>(entry->m_Asset);
 		}
 
 		auto descriptor = loadCubemapDescriptor(entry);
@@ -377,7 +377,7 @@ namespace annileen
 		std::tie(handle, info, imageContainer) = loadTextureData(descriptor.m_StripFile, {});
 
 		auto cubemap = std::make_shared<Cubemap>(handle, info, imageContainer->m_orientation);
-		entry->m_Asset = dynamic_pointer_cast<AssetObject>(cubemap);
+		entry->m_Asset = static_pointer_cast<AssetObject>(cubemap);
 		entry->m_Loaded = true;
 		return cubemap;
 	}
@@ -387,14 +387,14 @@ namespace annileen
 		auto entry = getAssetEntry(name);
 		if (entry->m_Loaded)
 		{
-			return dynamic_pointer_cast<MeshGroup>(entry->m_Asset);
+			return static_pointer_cast<MeshGroup>(entry->m_Asset);
 		}
 
 		const auto descriptor = loadMeshDescriptor(entry);
 
 		ModelLoader loader;
 		auto meshGroup = loader.loadMesh(entry->m_Filepath, descriptor);
-		entry->m_Asset = dynamic_pointer_cast<AssetObject>(meshGroup);
+		entry->m_Asset = static_pointer_cast<AssetObject>(meshGroup);
 		entry->m_Loaded = true;
 		return meshGroup;
 	}
@@ -404,11 +404,11 @@ namespace annileen
 		auto entry = getAssetEntry(name);
 		if (entry->m_Loaded)
 		{
-			return dynamic_pointer_cast<Font>(entry->m_Asset);
+			return static_pointer_cast<Font>(entry->m_Asset);
 		}
 
 		auto font = std::make_shared<Font>(entry->m_Filepath);
-		entry->m_Asset = dynamic_pointer_cast<AssetObject>(font);
+		entry->m_Asset = static_pointer_cast<AssetObject>(font);
 		entry->m_Loaded = true;
 		return font;
 	}

--- a/annileen/engine/assetmanager.ixx
+++ b/annileen/engine/assetmanager.ixx
@@ -29,7 +29,7 @@ export namespace annileen
 	{
 	private:
 		std::map<std::string, std::shared_ptr<AssetTableEntry>> m_Assets;
-		AssetWatcher* m_Watcher;
+		std::unique_ptr<AssetWatcher> m_Watcher;
 
 		void loadAssetTable(const std::string& assetfile);
 		AssetType getType(const std::string& typetext);
@@ -86,7 +86,7 @@ namespace annileen
 
 			size_t pos = assetfile.find_last_of("\\/");
 			auto path = std::string::npos == pos ? "" : assetfile.substr(0, pos);
-			m_Watcher = new AssetWatcher(path);
+			m_Watcher = std::make_unique<AssetWatcher>(path);
 		}
 		catch (const std::runtime_error&)
 		{
@@ -306,7 +306,6 @@ namespace annileen
 
 	AssetManager::~AssetManager()
 	{
-		delete m_Watcher;
 		unloadAssets();
 
 		// TODO: remove

--- a/annileen/engine/assetwatcher.ixx
+++ b/annileen/engine/assetwatcher.ixx
@@ -6,6 +6,7 @@ module;
 #include <functional>
 #include <tuple>
 #include <vector>
+#include <iostream>
 
 export module assetwatcher;
 
@@ -32,6 +33,7 @@ export namespace annileen
 
 	public:
 		AssetWatcher(const std::string& path);
+		~AssetWatcher();
 		void update();
 
 		inline std::unordered_map<std::string, AssetFileStatus>& getModified() { return m_Modified; }
@@ -49,6 +51,12 @@ namespace annileen
 		{
 			m_AssetFiles[file.path().string()] = std::filesystem::last_write_time(file);
 		}
+	}
+
+	AssetWatcher::~AssetWatcher()
+	{
+		// TODO: remove
+		std::cout << "AssetWatcher destroyed." << std::endl;
 	}
 
 	void AssetWatcher::update()

--- a/annileen/engine/cubemap.ixx
+++ b/annileen/engine/cubemap.ixx
@@ -40,5 +40,7 @@ namespace annileen
 
 	Cubemap::~Cubemap()
 	{
+		// TODO: remove
+		std::cout << "Cubemap destroyed." << std::endl;
 	}
 }

--- a/annileen/engine/engine.ixx
+++ b/annileen/engine/engine.ixx
@@ -419,6 +419,7 @@ namespace annileen
         ServiceProvider::provideSettings(nullptr);
 
         m_AssetManager.reset();
+        m_Renderer.reset();
 
         //TODO: destroy fonts before font manager
         //Font::destroyFontManager();

--- a/annileen/engine/mesh.ixx
+++ b/annileen/engine/mesh.ixx
@@ -35,14 +35,14 @@ export namespace annileen
 
 		void unload();
 
-		Mesh();
+		Mesh() = default;
 		~Mesh();
 	};
 
 	class MeshGroup : public AssetObject
 	{
 	public:
-		std::vector<Mesh*> m_Meshes;
+		std::vector<std::shared_ptr<Mesh>> m_Meshes;
 		~MeshGroup();
 	};
 }
@@ -76,20 +76,19 @@ namespace annileen
 		}
 	}
 
-	Mesh::Mesh()
-	{
-	}
-
 	Mesh::~Mesh()
 	{
 		unload();
+
+		// TODO: remove
+		std::cout << "Mesh destroyed." << std::endl;
 	}
 
 	MeshGroup::~MeshGroup()
 	{
-		for (auto& m : m_Meshes)
-		{
-			delete m;
-		}
+		m_Meshes.clear();
+
+		// TODO: remove
+		std::cout << "MeshGroup destroyed." << std::endl;
 	}
 }

--- a/annileen/engine/model.ixx
+++ b/annileen/engine/model.ixx
@@ -15,51 +15,57 @@ export namespace annileen
 
 	class Model final : public SceneNodeModule
 	{
-	private:
-		MeshGroup* m_MeshGroup = nullptr;
-		std::shared_ptr<Material> m_Material = nullptr;
-
-	public:
-		bool castShadows;
-		bool receiveShadows;
-
-		// Should this be moved to a parent component class? Will model be a "component"?
-		bool isStatic;
-		bool enabled;
-
-		void init(MeshGroup* meshGroup, std::shared_ptr<Material> material);
-
-		void setMeshGroup(MeshGroup* meshGroup) { m_MeshGroup = meshGroup; }
-		MeshGroup* getMeshGroup() const { return m_MeshGroup; }
-		std::shared_ptr<Material> getMaterial();
-
+	public:	
 		Model();
 		~Model();
+
+		void init(std::shared_ptr<MeshGroup> meshGroup, std::shared_ptr<Material> material);
+		void setMeshGroup(std::shared_ptr<MeshGroup> meshGroup);
+		std::shared_ptr<MeshGroup> getMeshGroup() const;
+		std::shared_ptr<Material> getMaterial() const;
+
+	public:
+		bool castShadows{ true };
+		bool receiveShadows{ true };
+
+		// Should this be moved to a parent component class? Will model be a "component"?
+		bool isStatic{ false };
+		bool enabled{ true };
+
+	private:
+		std::shared_ptr<MeshGroup> m_MeshGroup{ nullptr };
+		std::shared_ptr<Material> m_Material{ nullptr };
 	};
-
 }
-
 
 namespace annileen
 {
-	void Model::init(MeshGroup* meshGroup, std::shared_ptr<Material> material)
+	Model::~Model()
+	{
+		// TODO: remove
+		std::cout << "Model destroyed." << std::endl;
+	}
+
+	void Model::init(std::shared_ptr<MeshGroup> meshGroup, std::shared_ptr<Material> material)
 	{
 		m_MeshGroup = meshGroup;
 		m_Material = material;
 	}
 
-	std::shared_ptr<Material> Model::getMaterial()
+	void Model::setMeshGroup(std::shared_ptr<MeshGroup> meshGroup) 
+	{ 
+		m_MeshGroup = meshGroup; 
+	}
+
+	std::shared_ptr<MeshGroup> Model::getMeshGroup() const 
+	{ 
+		return m_MeshGroup; 
+	}
+
+	std::shared_ptr<Material> Model::getMaterial() const
 	{
 		return m_Material;
 	}
 
-	Model::Model() : SceneNodeModule(), m_MeshGroup(nullptr), m_Material(nullptr), castShadows(true),
-		receiveShadows(true), isStatic(false), enabled(true)
-	{
-	}
-
-	Model::~Model()
-	{
-
-	}
+	Model::Model() : SceneNodeModule() {}
 }

--- a/annileen/engine/modelloader.ixx
+++ b/annileen/engine/modelloader.ixx
@@ -4,40 +4,35 @@ module;
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
 #include "engine/core/logger.h"
+#include <memory>
 
 export module modelloader;
 
 import rawmesh;
 import mesh;
+import asset;
 
 export namespace annileen
 {
 	class ModelLoader
 	{
-	private:
-		void processNode(aiNode* node, const aiScene* scene, MeshGroup* meshGroup, const MeshDescriptor& descriptor);
-		void convertMesh(Mesh* mesh, aiMesh* aiMesh, const aiScene* scene, const MeshDescriptor& descriptor);
 	public:
-		ModelLoader();
-		~ModelLoader();
+		ModelLoader() = default;
+		~ModelLoader() = default;
 
-		MeshGroup* loadMesh(const std::string& filename, const MeshDescriptor& descriptor);
+		std::shared_ptr<MeshGroup> loadMesh(const std::string& filename, const MeshDescriptor& descriptor);
+	
+	private:
+		void processNode(aiNode* node, const aiScene* scene, std::shared_ptr<MeshGroup> meshGroup, const MeshDescriptor& descriptor);
+		void convertMesh(std::shared_ptr<Mesh> mesh, aiMesh* aiMesh, const aiScene* scene, const MeshDescriptor& descriptor);
 	};
 }
 
 namespace annileen
 {
-	ModelLoader::ModelLoader()
+	std::shared_ptr<MeshGroup> ModelLoader::loadMesh(const std::string& filename, const MeshDescriptor& descriptor)
 	{
-	}
-
-	ModelLoader::~ModelLoader()
-	{
-	}
-
-	MeshGroup* ModelLoader::loadMesh(const std::string& filename, const MeshDescriptor& descriptor)
-	{
-		MeshGroup* meshGroup = new MeshGroup();
+		auto meshGroup = std::make_shared<MeshGroup>();
 
 		Assimp::Importer importer;
 		
@@ -60,12 +55,12 @@ namespace annileen
 		return meshGroup;
 	}
 
-	void ModelLoader::processNode(aiNode* node, const aiScene* scene, MeshGroup* meshGroup, const MeshDescriptor& descriptor)
+	void ModelLoader::processNode(aiNode* node, const aiScene* scene, std::shared_ptr<MeshGroup> meshGroup, const MeshDescriptor& descriptor)
 	{
  		for (uint16_t i = 0; i < node->mNumMeshes; i++)
 		{
-			aiMesh* aiMesh = scene->mMeshes[node->mMeshes[i]];
-			Mesh* mesh = new Mesh();
+			auto aiMesh = scene->mMeshes[node->mMeshes[i]];
+			auto mesh = std::make_shared<Mesh>();
 			convertMesh(mesh, aiMesh, scene, descriptor);
 			meshGroup->m_Meshes.push_back(mesh);
 		}
@@ -76,7 +71,7 @@ namespace annileen
 		}
 	}
 
-	void ModelLoader::convertMesh(Mesh* mesh, aiMesh* aiMesh, const aiScene* scene, const MeshDescriptor& descriptor)
+	void ModelLoader::convertMesh(std::shared_ptr<Mesh> mesh, aiMesh* aiMesh, const aiScene* scene, const MeshDescriptor& descriptor)
 	{
 		RawMesh rawMesh;
 

--- a/annileen/engine/rawmesh.ixx
+++ b/annileen/engine/rawmesh.ixx
@@ -26,14 +26,14 @@ export namespace annileen
 
 	class RawMesh
 	{
+	public:		
+		void getMesh(std::shared_ptr<Mesh> mesh, const MeshDescriptor& descriptor);
 	private:
 		void generateNormals();
-
+	
 	public:
-		std::vector<RawVertex> m_Vertices;
-		std::vector<uint32_t> m_Indices;
-
-		void getMesh(Mesh* mesh, const MeshDescriptor& descriptor);
+		std::vector<RawVertex> m_Vertices{};
+		std::vector<uint32_t> m_Indices{};
 	};
 }
 
@@ -64,7 +64,7 @@ namespace annileen
 		}
 	}
 
-	void RawMesh::getMesh(Mesh* mesh, const MeshDescriptor& descriptor)
+	void RawMesh::getMesh(std::shared_ptr<Mesh> mesh, const MeshDescriptor& descriptor)
 	{
 		if (descriptor.m_Normals == MeshDescriptor::Normals::Generate)
 			generateNormals();

--- a/annileen/engine/renderer.ixx
+++ b/annileen/engine/renderer.ixx
@@ -33,22 +33,23 @@ export namespace annileen
 {
     struct Shadow
     {
-        bool useShadowSampler;
-        std::shared_ptr<Material> material;
-        bgfx::FrameBufferHandle frameBuffer;
-        Texture* texture;
-        uint8_t textureRegisterId;
+        bool useShadowSampler{ false };
+        std::shared_ptr<Material> material{ nullptr };
+        bgfx::FrameBufferHandle frameBuffer{ 0 };
+        std::shared_ptr<Texture> texture{ nullptr };
+        uint8_t textureRegisterId{ 0 };
     };
 
     class Renderer
     {
     private:
-        int m_ScreenWidth;
-        int m_ScreenHeight;
         const bgfx::Caps* m_Capabilities{ nullptr };
-        const bgfx::ViewId m_ViewId = 0;
+        const bgfx::ViewId m_ViewId{ 0 };
 
-        Shadow* m_Shadow{ nullptr };
+        int m_ScreenWidth{ 0 };
+        int m_ScreenHeight{ 0 };
+
+        std::unique_ptr<Shadow> m_Shadow{ nullptr };
 
         RenderView* m_SceneRenderView;
         RenderView* m_ShadowRenderView;
@@ -85,7 +86,7 @@ namespace annileen
 {
     void Renderer::initializeShadows()
     {
-        m_Shadow = new Shadow();
+        m_Shadow = std::make_unique<Shadow>();
 
         bgfx::VertexLayout ms_layout;
         ms_layout
@@ -98,8 +99,8 @@ namespace annileen
         // compare less equal feature is supported.
         m_Shadow->useShadowSampler = 0 != (m_Capabilities->supported & BGFX_CAPS_TEXTURE_COMPARE_LEQUAL);;
 
-        Shader* shader = ServiceProvider::getAssetManager()->getShader("sms_shadow");
-        std::shared_ptr<ShaderPass> shaderPass = std::make_shared<ShaderPass>();
+        auto shader = ServiceProvider::getAssetManager()->getShader("sms_shadow");
+        auto shaderPass = std::make_shared<ShaderPass>();
 
         shaderPass->init(shader);
         shaderPass->setState(0
@@ -138,7 +139,7 @@ namespace annileen
             1,
             bgfx::TextureFormat::D16);
 
-        m_Shadow->texture = new Texture(fbtextures[0], textureInfo, bimg::Orientation::R0);
+        m_Shadow->texture = std::make_shared<Texture>(fbtextures[0], textureInfo, bimg::Orientation::R0);
         m_Shadow->textureRegisterId = 1;
     }
 

--- a/annileen/engine/shader.ixx
+++ b/annileen/engine/shader.ixx
@@ -55,6 +55,9 @@ namespace annileen
     Shader::~Shader()
     {
         destroy();
+
+        // TODO: remove
+        std::cout << "Shader destroyed." << std::endl;
     }
 
     void Shader::setHandle(bgfx::ProgramHandle handle)

--- a/annileen/engine/shaderpass.ixx
+++ b/annileen/engine/shaderpass.ixx
@@ -3,6 +3,7 @@ module;
 #include <memory>
 #include <vector>
 #include <bgfx/defines.h>
+#include <iostream>
 
 export module shaderpass;
 
@@ -12,13 +13,13 @@ export namespace annileen
 {
     class ShaderPass
     {
-        Shader* m_Shader;
+        std::shared_ptr<Shader> m_Shader;
         uint64_t m_State;
 
     public:
-        void init(Shader* shader) noexcept;
+        void init(std::shared_ptr<Shader> shader) noexcept;
 
-        Shader* getShader() const noexcept;
+        std::shared_ptr<Shader> getShader() const noexcept;
 
         inline void setState(uint64_t state) { m_State = state; }
         inline uint64_t getState() { return m_State; }
@@ -27,15 +28,20 @@ export namespace annileen
             return m_Shader->getAvailableShaders();
         }
 
-        ShaderPass();
+        ShaderPass() = default;
         ~ShaderPass();
     };
 };
 
-
 namespace annileen
 {
-    void ShaderPass::init(Shader* shader) noexcept
+    ShaderPass::~ShaderPass()
+    {
+        // TODO: remove
+        std::cout << "ShaderPass destroyed." << std::endl;
+    }
+
+    void ShaderPass::init(std::shared_ptr<Shader> shader) noexcept
     {
         m_Shader = shader;
 
@@ -48,17 +54,9 @@ namespace annileen
             | UINT64_C(0); 
     }
 
-    Shader* ShaderPass::getShader() const noexcept
+    std::shared_ptr<Shader> ShaderPass::getShader() const noexcept
     {
         return m_Shader;
-    }
-
-    ShaderPass::ShaderPass()
-    {
-    }
-
-    ShaderPass::~ShaderPass()
-    {
     }
 }
 

--- a/annileen/engine/skybox.ixx
+++ b/annileen/engine/skybox.ixx
@@ -4,6 +4,7 @@ module;
 #include <bgfx/bgfx.h>
 
 #include <memory>
+#include <iostream>
 
 export module skybox;
 
@@ -47,30 +48,47 @@ export namespace annileen
 {
 	class Skybox
 	{
-	private:
-		std::shared_ptr<Model> m_Model;
-		MeshGroup* m_MeshGroup;
-		Cubemap* m_Cubemap;
-		void createModel();
-
 	public:
-		std::shared_ptr<Model> getModel() const { return m_Model; }
-		Cubemap* getCubemap() const { return m_Cubemap; }
-
-		Skybox(Cubemap* cubemap);
+		Skybox(std::shared_ptr<Cubemap> cubemap);
 		~Skybox();
+
+		std::shared_ptr<Model> getModel() const;
+		std::shared_ptr<Cubemap> getCubemap() const;
+	
+	private:
+		void createModel();
+	
+	private:
+		std::shared_ptr<Model> m_Model{ nullptr };
+		std::shared_ptr<MeshGroup> m_MeshGroup{ nullptr };
+		std::shared_ptr<Cubemap> m_Cubemap{ nullptr };
 	};
 }
 
-
 namespace annileen
 {
+	Skybox::~Skybox()
+	{
+		// TODO: remove
+		std::cout << "Skybox destroyed." << std::endl;
+	}
+
+	std::shared_ptr<Model> Skybox::getModel() const 
+	{ 
+		return m_Model; 
+	}
+
+	std::shared_ptr<Cubemap> Skybox::getCubemap() const 
+	{ 
+		return m_Cubemap; 
+	}
+
 	void Skybox::createModel()
 	{
-		Shader* shader = ServiceProvider::getAssetManager()->getShader("skybox");
-		std::shared_ptr<Material> material = std::make_shared<Material>();
+		auto shader{ ServiceProvider::getAssetManager()->getShader("skybox") };
+		auto material{ std::make_shared<Material>() };
 		
-		std::shared_ptr<ShaderPass> shaderPass = std::make_shared<ShaderPass>();
+		auto shaderPass{ std::make_shared<ShaderPass>() };
 		shaderPass->init(shader);
 		shaderPass->setState(BGFX_STATE_WRITE_RGB
 			| BGFX_STATE_DEPTH_TEST_LEQUAL
@@ -86,11 +104,11 @@ namespace annileen
 			.add(bgfx::Attrib::Position, 3, bgfx::AttribType::Float)
 			.end();
 
-		auto vdata = bgfx::makeRef(s_skyboxCubeVertices, sizeof(s_skyboxCubeVertices));
-		auto idata = bgfx::makeRef(s_skyboxCubeTriList, sizeof(s_skyboxCubeTriList));
+		auto vdata{ bgfx::makeRef(s_skyboxCubeVertices, sizeof(s_skyboxCubeVertices)) };
+		auto idata{ bgfx::makeRef(s_skyboxCubeTriList, sizeof(s_skyboxCubeTriList)) };
 
-		m_MeshGroup = new MeshGroup();
-		auto mesh = new Mesh();
+		m_MeshGroup = std::make_shared<MeshGroup>();
+		auto mesh{ std::make_shared<Mesh>() };
 		mesh->init(vdata, vlayout, idata);
 		m_MeshGroup->m_Meshes.push_back(mesh);
 
@@ -98,13 +116,8 @@ namespace annileen
 		m_Model->init(m_MeshGroup, material);
 	}
 
-	Skybox::Skybox(Cubemap* cubemap) : m_Cubemap(cubemap)
+	Skybox::Skybox(std::shared_ptr<Cubemap> cubemap) : m_Cubemap(cubemap)
 	{
 		createModel();
-	}
-	
-	Skybox::~Skybox()
-	{
-		delete m_MeshGroup;
-	}
+	}	
 }

--- a/annileen/engine/uniform.ixx
+++ b/annileen/engine/uniform.ixx
@@ -35,8 +35,8 @@ export namespace annileen
 		static bgfx::UniformHandle getSMat3UniformHandle(const std::string& uniformname);
 		static bgfx::UniformHandle getMat4UniformHandle(const std::string& uniformname);
 
-		static void setCubemapUniform(const std::string& uniformname, const Cubemap* value, uint8_t registerId);
-		static void setTextureUniform(const std::string& uniformname, const Texture* value, uint8_t registerId);
+		static void setCubemapUniform(const std::string& uniformname, std::shared_ptr<const Cubemap> value, uint8_t registerId);
+		static void setTextureUniform(const std::string& uniformname, std::shared_ptr<const Texture> value, uint8_t registerId);
 		static void setColorUniform(const std::string& uniformname, const glm::vec4& value);
 		static void setVec4Uniform(const std::string& uniformname, const glm::vec4& value);
 		static void setVec3Uniform(const std::string& uniformname, const glm::vec3& value);
@@ -100,14 +100,19 @@ namespace annileen
 		return getOrCreateUniform(uniformname, bgfx::UniformType::Mat4);
 	}
 
-	void Uniform::setCubemapUniform(const std::string& uniformname, const Cubemap* value, uint8_t registerId)
+	void Uniform::setCubemapUniform(const std::string& uniformname, std::shared_ptr<const Cubemap> value, uint8_t registerId)
 	{
 		bgfx::setTexture(registerId, getSamplerUniformHandle(uniformname), value->getHandle());
 	}
 
-	void Uniform::setTextureUniform(const std::string& uniformname, const Texture* value, uint8_t registerId)
+	void Uniform::setTextureUniform(const std::string& uniformname, std::shared_ptr<const Texture> value, uint8_t registerId)
 	{
 		bgfx::setTexture(registerId, getSamplerUniformHandle(uniformname), value->getHandle());
+	}
+
+	void Uniform::setColorUniform(const std::string& uniformname, const glm::vec4& value)
+	{
+		setVec4Uniform(uniformname, value);
 	}
 
 	void Uniform::setVec4Uniform(const std::string& uniformname, const glm::vec4& value)
@@ -141,5 +146,7 @@ namespace annileen
 		{
 			bgfx::destroy(v.m_Handle);
 		}
+
+		m_Uniforms.clear();
 	}
 }

--- a/annileen/examples/cube/applicationcube.ixx
+++ b/annileen/examples/cube/applicationcube.ixx
@@ -43,7 +43,7 @@ std::shared_ptr<Scene> ApplicationCube::init()
 {
     auto scene = SceneManager::getInstance()->createScene<Scene>();
 
-    annileen::Shader* shader = nullptr;
+    std::shared_ptr<annileen::Shader> shader = nullptr;
     if (ServiceProvider::getSettings()->getData()->shadows.enabled)
     {
         shader = ServiceProvider::getAssetManager()->getShader("lit_shadow");

--- a/annileen/examples/worldbuilding/chunk.ixx
+++ b/annileen/examples/worldbuilding/chunk.ixx
@@ -5,6 +5,7 @@ module;
 #include <PerlinNoise.hpp>
 #include <engine/forward_decl.h>
 #include <tuple>
+#include <iostream>
 #include <time.h>
 #include <glm.hpp>
 #include <bgfx/bgfx.h>
@@ -53,8 +54,8 @@ private:
 
     BlockType* m_Grid;
 
-    std::shared_ptr<Material> m_Material;
-    MeshGroup* m_MeshGroup = nullptr;
+    std::shared_ptr<Material> m_Material{ nullptr };
+    std::shared_ptr<MeshGroup> m_MeshGroup{ nullptr };
     ModelPtr m_Model = nullptr;
     SceneNodePtr m_Node = nullptr;
 
@@ -79,10 +80,9 @@ void Chunk::generateMesh()
     if (m_MeshGroup != nullptr)
     {
         delete m_Node;
-        delete m_MeshGroup;
     }
 
-    m_MeshGroup = new annileen::MeshGroup();
+    m_MeshGroup = std::make_shared<annileen::MeshGroup>();
 
     int meshSize;
     float* meshData = generateMeshData(&meshSize);
@@ -94,7 +94,7 @@ void Chunk::generateMesh()
         .add(bgfx::Attrib::Normal, 3, bgfx::AttribType::Float)
         .end();
 
-    auto mesh = new annileen::Mesh();
+    auto mesh = std::make_shared<annileen::Mesh>();
     mesh->init(bgfx::makeRef(meshData, meshSize * sizeof(float), annileen::Allocators::releaseMem), vlayout);
     m_MeshGroup->m_Meshes.push_back(mesh);
 }
@@ -300,6 +300,8 @@ Chunk::Chunk(int wx, int wz)
 
 Chunk::~Chunk()
 {
-    delete m_MeshGroup;
     delete m_Grid;
+
+    // TODO: remove
+    std::cout << "Chunk destroyed." << std::endl;
 }

--- a/annileen/examples/worldbuilding/gamescene.ixx
+++ b/annileen/examples/worldbuilding/gamescene.ixx
@@ -63,7 +63,7 @@ void GameScene::buildMap()
 {
     auto texture = ServiceProvider::getAssetManager()->getTexture("blocks.png");
 
-    annileen::Shader* shader = nullptr;
+    std::shared_ptr<annileen::Shader> shader{ nullptr };
     if (ServiceProvider::getSettings()->getData()->shadows.enabled)
     {
         shader = ServiceProvider::getAssetManager()->getShader("lit_shadow");
@@ -73,7 +73,7 @@ void GameScene::buildMap()
         shader = ServiceProvider::getAssetManager()->getShader("lit_noshadow");
     }
 
-    std::shared_ptr<ShaderPass> shaderPass = std::make_shared<ShaderPass>();
+    auto shaderPass = std::make_shared<ShaderPass>();
     shaderPass->init(shader);
     shaderPass->setState(BGFX_STATE_WRITE_RGB
         | BGFX_STATE_WRITE_A


### PR DESCRIPTION
Refactored `AssetManager` to hold resources using `shared_ptr` instead of raw pointers. Then, fixed all other classes affected by the changes above.